### PR TITLE
correct rep_free + abort on diff stack start address

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = $(REP_CFLAGS) -O0 -fpic
+AM_CFLAGS = $(REP_CFLAGS) -g -O0 -fpic
 
 export GOPATH = @abs_srcdir@
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ This project is a fault tolerance framework for parallel applications. Below is 
 | 2        | Process Replication 							| master (OK) 	|
 | 3        | Full-context Application Level Checkpointing  	| master (OK) 	|
 | 4		   | Fault Injector									| master (OK) 	|
-| 5	 	   | Process Manager 								| wip 			|
-| 6        | User Level Checkpointing      					| future 		|
+| 5	 	   | Process Manager 								| master (OK) 	|
+| 6	 	   | Custom Compiler (around mpicc) 				| wip 			|
+| 7        | User Level Checkpointing      					| future 		|
 
 ## MPI Functions Supported
 
@@ -31,7 +32,7 @@ This project is a fault tolerance framework for parallel applications. Below is 
 | 10 		| ```MPI_Allgather``` 							| master (OK) 	|
 | 11 		| ```MPI_Reduce``` 								| master (OK) 	|
 | 12 		| ```MPI_Allreduce``` 							| master (OK) 	|
-| 13 		| ```MPI_*``` (Async calls) 					| wip 		 	|
+| 13 		| ```MPI_*``` (Async calls) 					| future 		 	|
 
 ## API
 

--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -1,6 +1,6 @@
 lib_LTLIBRARIES += libreplication.la
 libreplication_la_SOURCES =  
-libreplication_la_CFLAGS = $(REP_CFLAGS) -O0 -shared
+libreplication_la_CFLAGS = $(REP_CFLAGS) -g -O0 -shared
 
 noinst_HEADERS = src/shared.h
 

--- a/src/checkpoint/full_context.c
+++ b/src/checkpoint/full_context.c
@@ -147,6 +147,8 @@ void restore_heap_seg() {
 		address *pointer_to_heap = (address *)temp_container.container_address;
 
 		*pointer_to_heap = malloc(temp_container.size);
+		temp_container.allocated_address = *pointer_to_heap;
+		debug_log_i("Malloc given add: %p", temp_container.allocated_address);
 
 		fread(*pointer_to_heap, temp_container.size, 1, ckpt_file);
 

--- a/src/mpi/init.c
+++ b/src/mpi/init.c
@@ -54,6 +54,16 @@ int __pass_receiver_cont_add;
 
 extern Malloc_list *head;
 
+void __attribute__((constructor)) calledFirst(void)
+{	
+	int a;
+    printf("\nI am called first %p : %d \n", &a, getpid());
+    int hang = 1;
+	/*while(hang) {
+		sleep(2);
+	}*/
+}
+
 void *rep_thread_init(void *_stackHigherAddress) {
 	 	// Higher end address (stack grows higher to lower address)
 	stackHigherAddress = (address *)_stackHigherAddress;

--- a/src/mpi/init.c
+++ b/src/mpi/init.c
@@ -153,6 +153,7 @@ int MPI_Init(int *argc, char ***argv) {
 	debug_log_i("WORLD_COMM Dup: %p", node.rep_mpi_comm_world);
 
 	address stackStart;
+	address temp_stackStart;
 
 	// Getting RBP only works if optimisation level is zero (O0).
 	// O1 removes RBP's use.
@@ -165,6 +166,13 @@ int MPI_Init(int *argc, char ***argv) {
 	}*/
 
 	stackStart = *argv;
+
+	PMPI_Allreduce(&stackStart, &temp_stackStart, sizeof(address), MPI_BYTE, MPI_BOR, node.rep_mpi_comm_world);
+
+	if(stackStart != temp_stackStart) {
+		PMPI_Abort(node.rep_mpi_comm_world, 100);
+		exit(2);
+	}
 
 	// Lock global mutex. This mutex will always be locked when user program is executing.
 	pthread_mutex_init(&global_mutex, NULL);

--- a/test/rep_collective_test.c
+++ b/test/rep_collective_test.c
@@ -19,6 +19,10 @@ void assign_data(float *buf, int size) {
 	}
 }
 
+//void __attribute__((constructor)) calledFirst();
+
+
+
 int main(int argc, char **argv) {
 	int ***n = argv;
 	printf("Add: %p\n", &argc);
@@ -34,10 +38,10 @@ int main(int argc, char **argv) {
 
 	//sleep(10);
 
-	if(size < 10) {
+	/*if(size < 10) {
 		printf("COMM_WORLD size should be >= 10\n");
 		MPI_Abort(comm, 1);
-	}
+	}*/
 
 	rep_malloc((void **)&big_buffer, sizeof(float) * SMALL_BUF_SIZE * size);
 	rep_malloc((void **)&small_buffer, sizeof(float) * SMALL_BUF_SIZE);
@@ -49,48 +53,48 @@ int main(int argc, char **argv) {
 	// BCAST STARTS
 	__pass_sender_cont_add = 1;
 
-	MPI_Bcast(&big_buffer, SMALL_BUF_SIZE * size, MPI_FLOAT, 0, comm);
+	MPI_Bcast(&big_buffer, SMALL_BUF_SIZE * size, MPI_FLOAT, 0 % size, comm);
 	sleep(SLEEP_TIME);
 
-	MPI_Bcast(&big_buffer, SMALL_BUF_SIZE * size, MPI_FLOAT, 1, comm);
+	MPI_Bcast(&big_buffer, SMALL_BUF_SIZE * size, MPI_FLOAT, 1 % size, comm);
 	sleep(SLEEP_TIME);
 	
-	MPI_Bcast(&big_buffer, SMALL_BUF_SIZE * size, MPI_FLOAT, 2, comm);
+	MPI_Bcast(&big_buffer, SMALL_BUF_SIZE * size, MPI_FLOAT, 2 % size, comm);
 	sleep(SLEEP_TIME);
 	
-	MPI_Bcast(&big_buffer, SMALL_BUF_SIZE * size, MPI_FLOAT, 3, comm);
+	MPI_Bcast(&big_buffer, SMALL_BUF_SIZE * size, MPI_FLOAT, 3 % size, comm);
 	sleep(SLEEP_TIME);
 	// BCAST ENDS
 
 
 	__pass_receiver_cont_add = 1;
 	// SCATTER STARTS
-	MPI_Scatter(&big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 0, comm);
+	MPI_Scatter(&big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 0 % size, comm);
 	sleep(SLEEP_TIME);
 
-	MPI_Scatter(&big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 3, comm);
+	MPI_Scatter(&big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 3 % size, comm);
 	sleep(SLEEP_TIME);
 
-	MPI_Scatter(&big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 8, comm);
+	MPI_Scatter(&big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 8 % size, comm);
 	sleep(SLEEP_TIME);
 
-	MPI_Scatter(&big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 5, comm);
+	MPI_Scatter(&big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 5 % size, comm);
 	sleep(SLEEP_TIME);
 	// SCATTER ENDS
 
 
 
 	// GATHER STARTS
-	MPI_Gather(&small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 8, comm);
+	MPI_Gather(&small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 8 % size, comm);
 	sleep(SLEEP_TIME);
 
-	MPI_Gather(&small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 3, comm);
+	MPI_Gather(&small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 3 % size, comm);
 	sleep(SLEEP_TIME);
 
-	MPI_Gather(&small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 2, comm);
+	MPI_Gather(&small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 2 % size, comm);
 	sleep(SLEEP_TIME);
 
-	MPI_Gather(&small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 9, comm);
+	MPI_Gather(&small_buffer, SMALL_BUF_SIZE, MPI_FLOAT, &big_buffer, SMALL_BUF_SIZE, MPI_FLOAT, 9 % size, comm);
 	sleep(SLEEP_TIME);
 	// GATHER ENDS
 
@@ -115,16 +119,16 @@ int main(int argc, char **argv) {
 	__pass_sender_cont_add = 0;
 	__pass_receiver_cont_add = 0;
 	// REDUCE STARTS
-	MPI_Reduce(&r_s, &r_r, 1, MPI_FLOAT, MPI_MAX, 5, comm);
+	MPI_Reduce(&r_s, &r_r, 1, MPI_FLOAT, MPI_MAX, 5 % size, comm);
 	sleep(SLEEP_TIME);
 
-	MPI_Reduce(&r_s, &r_r, 1, MPI_FLOAT, MPI_SUM, 2, comm);
+	MPI_Reduce(&r_s, &r_r, 1, MPI_FLOAT, MPI_SUM, 2 % size, comm);
 	sleep(SLEEP_TIME);
 
-	MPI_Reduce(&r_s, &r_r, 1, MPI_FLOAT, MPI_MIN, 8, comm);
+	MPI_Reduce(&r_s, &r_r, 1, MPI_FLOAT, MPI_MIN, 8 % size, comm);
 	sleep(SLEEP_TIME);
 
-	MPI_Reduce(&r_s, &r_r, 1, MPI_FLOAT, MPI_SUM, 7, comm);
+	MPI_Reduce(&r_s, &r_r, 1, MPI_FLOAT, MPI_SUM, 7 % size, comm);
 	sleep(SLEEP_TIME);
 	// REDUCE ENDS
 


### PR DESCRIPTION
Done:
1. Corrected ```rep_free``` implementation: Using ```container.allocated_address``` to free memeory but ```container.allocated_address``` was not assigned address (was giving double free error)
2. Added: Abort on different statck start address.
3. Updated some ```MPI_*``` functions to support pointer passing to functions.
4. Made ```rep_collective_test``` generic for any comm size.