### PR TITLE
Now transferring and saving __pass_****_cont_add also

### DIFF
--- a/src/checkpoint/full_context.h
+++ b/src/checkpoint/full_context.h
@@ -13,11 +13,13 @@ void init_ckpt(char *);
 void save_data_seg();
 void save_stack_seg();
 void save_heap_seg();
+void save_framework_data();
 
 void init_ckpt_restore(char *);
 void restore_data_seg();
 void restore_stack_seg();
 void restore_heap_seg();
+void restore_framework_data();
 
 int does_ckpt_file_exists(char *);
 

--- a/src/mpi/comm.c
+++ b/src/mpi/comm.c
@@ -51,6 +51,9 @@ int parse_map_file(char *file_name, Job **job_list, Node *node, enum CkptBackup 
 	int cores, jobs;
 	fscanf(pointer, "%d\t%d", &cores, &jobs);
 
+	// Reset node_checkpoint_master
+	(*node).node_checkpoint_master = NO;
+
 	// TODO: Optimise re-allocation of memory.
 	for(int i=0; i<(*node).jobs_count; i++) {
 		free((*job_list)[i].rank_list);
@@ -89,6 +92,7 @@ int parse_map_file(char *file_name, Job **job_list, Node *node, enum CkptBackup 
 
 			if(j == 0 && w_rank == my_rank) {
 				(*node).node_checkpoint_master = YES;
+				debug_log_i("CK MASTER: %d", (*node).node_checkpoint_master);
 			}
 
 			if(w_rank == my_rank && update_bit == 1) {

--- a/src/replication/rep.c
+++ b/src/replication/rep.c
@@ -16,6 +16,9 @@ extern Node node;
 
 extern Malloc_list *head;
 
+extern int __pass_sender_cont_add;
+extern int __pass_receiver_cont_add;
+
 /* 
 *  1. Checks for file update pointer from the replication thread.
 *  2. If set, do a setjmp(), MPI_wait_all() and switch to alternate stack.
@@ -102,7 +105,16 @@ int init_rep(MPI_Comm job_comm) {
 	PMPI_Barrier(job_comm);
 	transfer_heap_seg(job_comm);
 
+	// Send Framework related data
+	PMPI_Barrier(job_comm);
+	transfer_framework_data(job_comm);
+
 	log_i("Replication Complete.");
+}
+
+int transfer_framework_data(MPI_Comm job_comm) {
+	PMPI_Bcast(&__pass_sender_cont_add, 1, MPI_INT, 0, job_comm);
+	PMPI_Bcast(&__pass_receiver_cont_add, 1, MPI_INT, 0, job_comm);
 }
 
 void copy_jmp_buf(jmp_buf source, jmp_buf dest) {

--- a/src/replication/rep.h
+++ b/src/replication/rep.h
@@ -48,4 +48,6 @@ void copy_jmp_buf(jmp_buf, jmp_buf);
 */
 int initRep(MPI_Comm);
 
+int transfer_framework_data(MPI_Comm);
+
 #endif


### PR DESCRIPTION
```__pass_sender_cont_add``` and ```__pass_receiver_cont_add``` are used to know if container or actual buffer address is passed to ```MPI_*``` function. Accordingly sender and receiver buffers are set.

This is important when a pointer has to be passed to MPI functions.
Ref. #5 