### PR TITLE
Comm correction + manager cmd arguments

### DIFF
--- a/src/manager/manager/manager.go
+++ b/src/manager/manager/manager.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"flag"
 	"time"
 	"os"
 	"strconv"
@@ -11,16 +12,36 @@ import (
 )
 
 func main() {
-	fmt.Println("Process Manager")
 
-	_jm := InitJobMap(10, 16)
+	jobs := flag.Int("j", 0, "No of jobs")
+	ranks := flag.Int("r", 0, "Total ranks spawnned")
+	choose := flag.Int("c", 0, "No of ranks to choose to replace in each iteration")
+	timeR := flag.Int("t", 15, "Time between replication map updates")
+	flag.Parse()
+
+	if *jobs == 0 || *ranks == 0 {
+		fmt.Println("Please provide no of jobs and ranks ex: 'manager -j 10 -r 14'")
+		os.Exit(1)
+	}
+
+	if *choose == 0 {
+		*choose = *ranks - *jobs
+	}
+
+	fmt.Println("\nProcess Manager (simulation) started...")
+	fmt.Println("|-----------------------------|")
+	fmt.Println("|  No. of Jobs | No of Ranks  |")
+	fmt.Printf("|  %d          | %d           |\n", *jobs, *ranks)
+	fmt.Println("|-----------------------------|\n")
+
+	_jm := InitJobMap(*jobs, *ranks)
 	//jm := _jm.JMap
 	
 	for i := 0; i < 10; i++ {
-		c := _jm.Choose(9)
+		c := _jm.Choose(*choose)
 		_jm.Assign(c)
 
-		fmt.Println(i)
+		fmt.Printf("--> %d of %d updates\n", i+1, 10)
 
 		/*for _jid, _j := range jm {
 			fmt.Println(_jid, _j.GetNumberOfRanks())
@@ -30,7 +51,8 @@ func main() {
 
 		_jm.ResetModified()
 
-		time.Sleep(20 * time.Second)
+		dur := time.Duration(*timeR) * time.Second
+		time.Sleep(dur)
 	}
 	
 }

--- a/src/mpi/comm.c
+++ b/src/mpi/comm.c
@@ -53,6 +53,7 @@ int parse_map_file(char *file_name, Job **job_list, Node *node, enum CkptBackup 
 
 	// Reset node_checkpoint_master
 	(*node).node_checkpoint_master = NO;
+	(*node).node_transit_state = NODE_DATA_NONE;
 
 	// TODO: Optimise re-allocation of memory.
 	for(int i=0; i<(*node).jobs_count; i++) {
@@ -73,12 +74,12 @@ int parse_map_file(char *file_name, Job **job_list, Node *node, enum CkptBackup 
 		assert(j_id < jobs && "Check replication map for job id > no of jobs.");
 		assert(w_c > 0 && "Worker count for each job should be greater than zero.");
 
-		if(update_bit == 0) {
+		/*if(update_bit == 0) {
 			if((*node).job_id == j_id) {
 				(*node).node_transit_state = NODE_DATA_NONE;
 			}
 			//continue;
-		}
+		}*/
 
 		(*job_list)[j_id].job_id = j_id;
 		(*job_list)[j_id].worker_count = w_c;
@@ -125,6 +126,8 @@ int parse_map_file(char *file_name, Job **job_list, Node *node, enum CkptBackup 
 	for(int i=0; i<jobs; i++) {
 		debug_log_i("[Rep File Update] MyJobId: %d | Job ID: %d | Worker Count: %d | Worker 1: %d | Worker 2: %d | Checkpoint: %d", (*node).job_id, (*job_list)[i].job_id, (*job_list)[i].worker_count, (*job_list)[i].rank_list[0], (*job_list)[i].rank_list[1], (*node).node_checkpoint_master);
 	}
+
+	debug_log_i("node_transit_state: Sender: %d | Recv: %d | None: %d", (*node).node_transit_state = NODE_DATA_SENDER, (*node).node_transit_state = NODE_DATA_RECEIVER, (*node).node_transit_state = NODE_DATA_NONE);
 }
 
 // responsible to update 'world_job_comm' and 'active_comm' [defined in src/shared.h]

--- a/test/rep_collective_test.c
+++ b/test/rep_collective_test.c
@@ -156,5 +156,6 @@ int main(int argc, char **argv) {
 
 	MPI_Finalize();
 
+	MPI_Comm_rank(comm, &rank);
 	printf("*****DONE %d\n", rank);
 }


### PR DESCRIPTION
1. ```node_transit_state``` was incorrectly set to previous value after replication file update.
2. Also updated manager to receive arguments from command line.
3. Updated test ```rep_collective_test``` to fetch rank of a process just before using it. If this is not done, it will give incorrect rank after replication or checkpoint restore.
